### PR TITLE
Oleksii/QA-2763 Added handling of tcp ERRNO 35 error for socketio/websocket

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,14 @@
 Changelog
 ##########
 
+0.8dr3
+=====
+* Based on 0.8dr2
+* Added proper handling of tcp ERRNO 35 in websocket part of socketio communication
+* All other tcp error would rise an exception so it would be easily tracked in report
+* If any other tcp ERROR occurs exception would be raised, which cause user scenario interrupt. On further access to client reconnect will be executed.
+
+
 0.8dr2
 =====
 * Based on 0.8dr1

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 ##########
 
+0.8dr2
+=====
+* Based on 0.8dr1
+* Added config propagation. Locust able to be reconfigured without relounch
+* Added host setup through UI
+* HTTP error aggregation
+
 0.8dr1
 =====
 * Based on 0.8a2

--- a/docs/writing-a-locustfile.rst
+++ b/docs/writing-a-locustfile.rst
@@ -62,15 +62,6 @@ classes. Say for example, web users are three times more likely than mobile user
         ....
 
 
-The *host* attribute
---------------------
-
-The host attribute is a URL prefix (i.e. "http://google.com") to the host that is to be loaded. 
-Usually, this is specified on the command line, using the :code:`--host` option, when locust is started. 
-If one declares a host attribute in the locust class, it will be used in the case when no :code:`--host` 
-is specified on the command line.
-
-
 TaskSet class
 =============
 

--- a/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
+++ b/examples/custom_xmlrpc_client/xmlrpc_locustfile.py
@@ -41,7 +41,6 @@ class XmlRpcLocust(Locust):
 
 class ApiUser(XmlRpcLocust):
     
-    host = "http://127.0.0.1:8877/"
     min_wait = 100
     max_wait = 1000
     

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -1,5 +1,5 @@
 from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
-from .config import configure, locust_config
+from .config import configure, locust_config, register_config
 
 __version__ = "0.8dr1"

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .config import configure, locust_config, register_config
 
-__version__ = "0.8dr2"
+__version__ = "0.8dr3"

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .config import configure, locust_config, register_config
 
-__version__ = "0.8dr1"
+__version__ = "0.8dr2"

--- a/locust/clients/socketio.py
+++ b/locust/clients/socketio.py
@@ -199,7 +199,7 @@ class SocketIOClient(object):
                 pass
 
             def on_disconnect(self, reason):
-                raise SocketIODisconnectedError(reason)
+                raise SocketIODisconnectedError('SocketIO websocket exection: ' + reason)
 
             def on_event(self, event, *args):
                 msg = SocketIOMSG(event, args[0] if args else None)

--- a/locust/config.py
+++ b/locust/config.py
@@ -117,24 +117,28 @@ class LocustConfig(object):
             self._config[attr] = value
 
 # global locust config singleton
-locust_config = LocustConfig()
+_locust_config = LocustConfig()
+
+def locust_config():
+    return _locust_config
 
 def register_config(config):
+    global _locust_config
     """
     Update default locust configuration object with custom instance
     config argument should be instance of LocustConfig or inherited class
     """
     if not isinstance(config, LocustConfig):
         raise AttributeError('Config object sgould be instance of LocustConfig')
-    locust_config = config
+    _locust_config = config
 
 @contextmanager
 def configure():
     """locust configuration context manager"""
-    yield locust_config
+    yield _locust_config
 
 def process_options():
-    parser, opts, args = parse_options()
+    _parser, opts, args = parse_options()
     setup_logging(opts.loglevel, opts.logfile)
     with configure() as config:
         loglevel = opts.__dict__.pop('loglevel')
@@ -152,10 +156,10 @@ def process_options():
             setattr(config, attr, value)
 
     locusts = load_locusts(opts, args)
-    locust_config._apply()
-    locust_config._validate()
+    _locust_config._apply()
+    _locust_config._validate()
 
-    return locust_config, locusts
+    return _locust_config, locusts
 
 def parse_options():
     """

--- a/locust/config.py
+++ b/locust/config.py
@@ -10,7 +10,7 @@ from urlparse import urlparse
 from .core import Locust
 from .log import setup_logging
 
-__all__ = ['configure', 'locust_config', 'process_options']
+__all__ = ['configure', 'locust_config', 'process_options', 'register_config']
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +23,16 @@ class LocustConfig(object):
         'socketio_logging': 'locust.clients.socketio',
         'http_logging': 'locust.clients.http',
     }
+
+    STATIC_PARAMS = [
+        'web_host',
+        'web_port',
+        'no_web',
+        'master_host',
+        'master_port',
+        'master_bind_host',
+        'master_bind_port',
+    ]
 
     DEFAULT = {
         # Endpoints
@@ -77,6 +87,16 @@ class LocustConfig(object):
             )
             sys.exit(1)
 
+    def to_dict(self):
+        """Return config object as raw dict"""
+        return self._config.copy()
+
+    def update_config(self, config_dict):
+        """Update config object with raw dict"""
+        for k, v in config_dict.items():
+            if k not in self.STATIC_PARAMS:
+                self._config[k] = v
+
     @property
     def host(self):
         config = self._config
@@ -98,6 +118,15 @@ class LocustConfig(object):
 
 # global locust config singleton
 locust_config = LocustConfig()
+
+def register_config(config):
+    """
+    Update default locust configuration object with custom instance
+    config argument should be instance of LocustConfig or inherited class
+    """
+    if not isinstance(config, LocustConfig):
+        raise AttributeError('Config object sgould be instance of LocustConfig')
+    locust_config = config
 
 @contextmanager
 def configure():

--- a/locust/core.py
+++ b/locust/core.py
@@ -13,6 +13,7 @@ from six.moves import xrange
 
 from . import events
 from .clients import HttpSession, SocketIOClient, ZMQClient
+from .config import LocustConfig
 from .exception import (InterruptTaskSet, LocustError, RescheduleTask,
                         RescheduleTaskImmediately, StopLocust)
 
@@ -110,8 +111,12 @@ class Locust(object):
     def __init__(self):
         super(Locust, self).__init__()
         self.current_task = None
-        from .config import locust_config
-        self.config = locust_config
+        if hasattr(self, 'config'):
+            if not isinstance(self.config, LocustConfig):
+                raise AttributeError('Config object sgould be inherited from LocustConfig')
+        else:
+            from .config import locust_config
+            self.config = locust_config
         if not self.min_wait:
             self.min_wait = self.config.min_wait
         if not self.max_wait:

--- a/locust/log.py
+++ b/locust/log.py
@@ -8,10 +8,10 @@ def setup_logging(loglevel, logfile):
     numeric_level = getattr(logging, loglevel.upper(), None)
     if numeric_level is None:
         raise ValueError("Invalid log level: %s" % loglevel)
-    
+
     log_format = "[%(asctime)s] {0}/%(levelname)s/%(name)s: %(message)s".format(host)
     logging.basicConfig(level=numeric_level, filename=logfile, format=log_format)
-    
+
     sys.stderr = StdErrWrapper()
     sys.stdout = StdOutWrapper()
 

--- a/locust/main.py
+++ b/locust/main.py
@@ -1,11 +1,8 @@
-# import inspect
 import logging
-# import os
 import signal
 import socket
 import sys
 import time
-# from optparse import OptionParser
 
 import gevent
 
@@ -85,7 +82,11 @@ def main():
         runners.main.wait_for_slaves(options.expect_slaves)
         runners.main.start_hatching(options.num_clients, options.hatch_rate)
     else:
-        logger.info("Starting web monitor at %s:%s", options.web_host or "localhost", options.web_port)
+        logger.info(
+            "Starting web monitor at %s:%s",
+            options.web_host or "localhost",
+            options.web_port
+        )
         gevent.spawn(web.start, locusts, options)
 
     #### Stats, etc

--- a/locust/main.py
+++ b/locust/main.py
@@ -25,9 +25,13 @@ version = locust.__version__
 
 main_greenlet = None
 
-def main():
-
-    options, locusts = config.process_options()
+def launch(options, locusts):
+    """
+    Locust entrypoint, could be called for programmatical launch:
+        * options - Any object which implements field access by attribute
+                    Recommended to use extended locust.config.LocustConfig object
+        * locusts - list of locust classes inherited from locust.core.Locust
+    """
     logger = logging.getLogger(__name__)
 
     if options.show_version:
@@ -75,7 +79,7 @@ def main():
         main_greenlet = runners.main.greenlet
 
     # Headful / headless init
-    if options.no_web and options.slave:
+    if options.slave:
         logger.info("Slave connected in headless mode")
     elif options.no_web and not options.slave:
         logger.info("Starting headless execution")
@@ -122,6 +126,10 @@ def main():
         shutdown(code=code)
     except KeyboardInterrupt:
         shutdown(0)
+
+def main():
+    options, locusts = config.process_options()
+    launch(options, locusts)
 
 if __name__ == '__main__':
     main()

--- a/locust/runners/distributed.py
+++ b/locust/runners/distributed.py
@@ -40,9 +40,7 @@ class DistributedLocustRunner(object):
         self.state = STATE.INIT
         self.locust_classes = locust_classes
         self.options = options
-        self.host = options.host
         self.stats = global_stats
-        self.num_requests = options.num_requests
         self.master_host = options.master_host
         self.master_port = options.master_port
         self.master_bind_host = options.master_bind_host

--- a/locust/runners/slave.py
+++ b/locust/runners/slave.py
@@ -213,6 +213,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
         while True:
             gen = (w for w in self.workers.copy().itervalues() if not w.ping_answ)
             for dead_worker in gen:
+                logger.info("Worker does not respond. Killing it %s", dead_worker.id)
                 self.server.send_to(dead_worker.id, Message("quit", None, None))
                 self.task_pool.append(dead_worker.task)
                 del self.workers[dead_worker.id]

--- a/locust/runners/slave.py
+++ b/locust/runners/slave.py
@@ -35,10 +35,11 @@ class SlaveLocustRunner(DistributedLocustRunner):
 
         def on_hatch(self, msg):
             self.slave.state = STATE.HATCHING
-            self.slave.hatch_rate = msg.data["hatch_rate"]
-            self.slave.num_requests = msg.data["num_requests"]
-            self.slave.host = msg.data["host"]
+            self.slave.options.num_requests = msg.data["num_requests"]
             self.slave.start_hatching(msg.data["num_clients"], msg.data["hatch_rate"])
+
+        def on_new_config(self, msg):
+            self.slave.options.update_config(msg.data)
 
         def on_stop(self, msg):
             logger.info("Got stop message from master, stopping...")
@@ -243,7 +244,10 @@ class SlaveLocustRunner(DistributedLocustRunner):
         calc = lambda x: locust_count / worker_num + adjust(x)
         worker_locust_count = [calc(x) for x in range(1, worker_num + 1)]
         worker_hatch_rate = hatch_rate / float(worker_num)
-        worker_num_requests = self.num_requests / 4 if self.num_requests else None
+        if self.options.num_requests:
+            worker_num_requests = int(self.options.num_requests / worker_num)
+        else:
+            worker_num_requests = None
 
         logger.info("Sending hatch jobs to %d ready workers", worker_num)
 
@@ -251,9 +255,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
             data = {
                 "hatch_rate": worker_hatch_rate,
                 "num_clients": client_rate,
-                "num_requests": worker_num_requests,
-                "host": self.host,
-                "stop_timeout": None
+                "num_requests": worker_num_requests
             }
             self.server.send_to(slave_id, Message("hatch", data, None))
             self.workers[slave_id].task = data

--- a/locust/static/locust.js
+++ b/locust/static/locust.js
@@ -28,6 +28,12 @@ $("#new_test").click(function(event) {
     $("#locust_count").focus().select();
 });
 
+$("#new_target").click(function(event) {
+    event.preventDefault();
+    $("#config").show();
+    $("#host_url").focus().select();
+});
+
 $(".edit_test").click(function(event) {
     event.preventDefault();
     $("#edit").show();
@@ -80,6 +86,18 @@ $('#edit_form').submit(function(event) {
             if (response.success) {
                 $("body").attr("class", "hatching");
                 $("#edit").fadeOut();
+            }
+        }
+    );
+});
+
+$('#config_form').submit(function(event) {
+    event.preventDefault();
+    $.post($(this).attr("action"), $(this).serialize(),
+        function(response) {
+            if (response.success) {
+                $("#host_url").html(response.new_host);
+                $("#config").fadeOut();
             }
         }
     );

--- a/locust/static/style.css
+++ b/locust/static/style.css
@@ -156,7 +156,7 @@ a:hover {
     position: relative;
 }
 
-.start, .edit {
+.start, .edit, .config {
     width: 398px;
     position: absolute;
     left: 50%;
@@ -165,22 +165,22 @@ a:hover {
     z-index: 1;
 }
 
-.start .padder, .edit .padder {
+.start .padder, .edit .padder, .config .padder {
     padding: 30px;
     padding-top: 0px;
 }
-.start h2, .edit h2 {
+.start h2, .edit h2, .config h2 {
     color: #addf82;
     font-size: 26px;
     font-weight: bold;
 }
-.start label, .edit label {
+.start label, .edit label, .config label {
     display: block;
     margin-bottom: 10px;
     margin-top: 20px;
     font-size: 16px;
 }
-.start input.val, .edit input.val {
+.start input.val, .edit input.val, .config input.val {
     border: none;
     background: #fff;
     height: 52px;
@@ -189,7 +189,8 @@ a:hover {
     padding-left: 10px;
 }
 .start button,
-.edit button {
+.edit button,
+.config button {
     margin-top: 20px;
     float: right;
     font-size: 16px;
@@ -201,12 +202,13 @@ a:hover {
     cursor: pointer;
 }
 .start button:hover,
-.edit button:hover {
+.edit button:hover,
+.config button:hover {
     background: #74b99d;
 }
 
 
-.stopped .start {
+.stopped .start, .stopped .config {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
@@ -217,7 +219,8 @@ a:hover {
 }
 
 .stopped .edit {display: none;}
-.running .edit, .hatching .edit {
+.running .edit, .hatching .edit,  
+.running .config, .hatching .config {
     display: none;
     border-radius: 5px;
     -moz-border-radius: 5px;
@@ -228,7 +231,7 @@ a:hover {
 }
 .running .start, .hatching .start {display: none;}
 
-.ready .edit {display: none;}
+.ready .edit, .ready .config {display: none;}
 .ready .start {display: block;}
 
 .running .status, .hatching .status {display: block;}
@@ -242,13 +245,17 @@ a:hover {
 .running a.new_test {display: none;}
 .stopped a.new_test {display: block;}
 
-.start a.close_link, .edit a.close_link{
+.start a.close_link, .edit a.close_link, .config a.close_link {
     position: absolute;
     right: 10px;
     top: 10px;
 }
-.stopped .start a.close_link {display: inline;}
-.running .start a.close_link, .ready .start a.close_link, .hatching .start a.close_link  {display: none;}
+
+.stopped .start a.close_link, .stopped .config a.close_link {display: inline;}
+.running .start a.close_link, .ready .start a.close_link, .hatching .start a.close_link,
+.running .config a.close_link, .ready .config a.close_link, .hatching .config a.close_link  {
+    display: none;
+}
 
 .stopped .edit a.close_link, .ready .edit a.close_link {display: none;}
 .running .edit a.close_link, .hatching .edit a.close_link {display: inline;}

--- a/locust/templates/index.html
+++ b/locust/templates/index.html
@@ -15,6 +15,7 @@
                     <div class="value" id="host_url">
                         {{host}}
                     </div>
+                    <a href="#" class="new_test" id="new_target">New target</a>
                 </div>
                 <div class="top_box box_status">
                     <div class="label">STATUS</div>
@@ -64,6 +65,21 @@
                     <label for="hatch_rate">Hatch rate <span style="color:#8a8a8a;">(users spawned/second)</span></label>
                     <input type="text" name="hatch_rate" id="hatch_rate" class="val" /><br>
                     <button type="submit">Start swarming</button>
+                </form>
+                <div style="clear:right;"></div>
+            </div>
+        </div>
+
+        <div class="config" id="config">
+            <div style="position:relative;">
+                <a href="#" class="close_link">Close</a>
+            </div>
+            <div class="padder">
+                <h2>Set new target host</h2>
+                <form action="/config" method="POST" id="config_form">
+                    <label for="host_url">New target host URL</label>
+                    <input type="text" name="host_url" id="host_url" class="val" /><br>
+                    <button type="submit">Set target host</button>
                 </form>
                 <div style="clear:right;"></div>
             </div>

--- a/locust/test/test_config.py
+++ b/locust/test/test_config.py
@@ -7,6 +7,10 @@ from .testcases import LocustTestCase
 
 class TestTaskSet(LocustTestCase):
 
+    def tearDown(self):
+        super(TestTaskSet, self).tearDown()
+        config.locust_config = config.LocustConfig()
+
     def test_default_config(self):
         self.assertTrue(isinstance(config.locust_config, config.LocustConfig))
 
@@ -33,3 +37,21 @@ class TestTaskSet(LocustTestCase):
         locusts = config.load_locusts(MockOpts, [])
         self.assertEqual(len(locusts), 1)
 
+    def test_config_to_dict(self):
+        with locust.configure() as l_config:
+            l_config.http_logging = 'DEBUG'
+            l_config.custom_param = 'custom value'
+        config_dict = config.locust_config.to_dict()
+        self.assertIsInstance(config_dict, dict)
+        self.assertDictContainsSubset(
+            {'http_logging': 'DEBUG', 'custom_param':'custom value'},
+            config_dict
+        )
+        config_dict['http_logging'] = 'ERROR'
+        self.assertEqual(config.locust_config.http_logging, 'DEBUG')
+
+    def test_update_config_values(self):
+        updates = {'host': 'example.com', 'port': None, 'master_host': 'http_new_host'}
+        config.locust_config.update_config(updates)
+        self.assertEqual(config.locust_config.host, 'http://example.com')
+        self.assertEqual(config.locust_config.master_host, '127.0.0.1')

--- a/locust/test/test_config.py
+++ b/locust/test/test_config.py
@@ -9,18 +9,18 @@ class TestTaskSet(LocustTestCase):
 
     def tearDown(self):
         super(TestTaskSet, self).tearDown()
-        config.locust_config = config.LocustConfig()
+        config.register_config(config.LocustConfig())
 
     def test_default_config(self):
-        self.assertTrue(isinstance(config.locust_config, config.LocustConfig))
+        self.assertIsInstance(config.locust_config(), config.LocustConfig)
 
     def test_configure(self):
         with locust.configure() as l_config:
             l_config.http_logging = 'DEBUG'
             l_config.custom_param = 'custom value'
 
-        self.assertEqual(config.locust_config.http_logging, 'DEBUG')
-        self.assertEqual(config.locust_config.custom_param, 'custom value')
+        self.assertEqual(config.locust_config().http_logging, 'DEBUG')
+        self.assertEqual(config.locust_config().custom_param, 'custom value')
 
     def test_composite_host(self):
         with locust.configure() as l_config:
@@ -28,8 +28,8 @@ class TestTaskSet(LocustTestCase):
             l_config.scheme = 'https'
             l_config.port = '8080'
 
-        self.assertEqual(config.locust_config.host, 'https://example.com:8080')
-        self.assertEqual(config.locust_config.socket_io, 'https://example.com:8080')
+        self.assertEqual(config.locust_config().host, 'https://example.com:8080')
+        self.assertEqual(config.locust_config().socket_io, 'https://example.com:8080')
 
     def test_load_locusts(self):
         class MockOpts(object):
@@ -41,17 +41,17 @@ class TestTaskSet(LocustTestCase):
         with locust.configure() as l_config:
             l_config.http_logging = 'DEBUG'
             l_config.custom_param = 'custom value'
-        config_dict = config.locust_config.to_dict()
+        config_dict = config.locust_config().to_dict()
         self.assertIsInstance(config_dict, dict)
         self.assertDictContainsSubset(
             {'http_logging': 'DEBUG', 'custom_param':'custom value'},
             config_dict
         )
         config_dict['http_logging'] = 'ERROR'
-        self.assertEqual(config.locust_config.http_logging, 'DEBUG')
+        self.assertEqual(config.locust_config().http_logging, 'DEBUG')
 
     def test_update_config_values(self):
         updates = {'host': 'example.com', 'port': None, 'master_host': 'http_new_host'}
-        config.locust_config.update_config(updates)
-        self.assertEqual(config.locust_config.host, 'http://example.com')
-        self.assertEqual(config.locust_config.master_host, '127.0.0.1')
+        config.locust_config().update_config(updates)
+        self.assertEqual(config.locust_config().host, 'http://example.com')
+        self.assertEqual(config.locust_config().master_host, '127.0.0.1')

--- a/locust/test/test_http_client.py
+++ b/locust/test/test_http_client.py
@@ -35,7 +35,7 @@ class TestHttpSession(WebserverTestCase):
                 self.assertRaises(exception, s.get, "/")
             except KeyError:
                 self.fail("Invalid URL %s was not propagated" % url)
-    
+
     def test_streaming_response(self):
         """
         Test a request to an endpoint that returns a streaming response

--- a/locust/test/test_locust_class.py
+++ b/locust/test/test_locust_class.py
@@ -16,7 +16,7 @@ class TestTaskSet(LocustTestCase):
         class User(WebLocust):
             pass
 
-        self.locust = User(config.locust_config)
+        self.locust = User(config.locust_config())
 
     def test_task_ratio(self):
         t1 = lambda l: None
@@ -253,8 +253,8 @@ class TestTaskSet(LocustTestCase):
         class MyLocust2(Locust):
             task_set = MyTaskSet2
 
-        l = MyLocust(config.locust_config)
-        l2 = MyLocust2(config.locust_config)
+        l = MyLocust(config.locust_config())
+        l2 = MyLocust2(config.locust_config())
         self.assertRaises(LocustError, lambda: l.run())
         self.assertRaises(LocustError, lambda: l2.run())
         
@@ -285,7 +285,7 @@ class TestTaskSet(LocustTestCase):
         class MyLocust(Locust):
             task_set = SubTaskSet
 
-        l = MyLocust(config.locust_config)
+        l = MyLocust(config.locust_config())
         task_set = SubTaskSet(l)
         self.assertRaises(RescheduleTaskImmediately, lambda: task_set.run(reschedule=True))
         self.assertRaises(RescheduleTask, lambda: task_set.run(reschedule=False))
@@ -311,7 +311,7 @@ class TestTaskSet(LocustTestCase):
         class MyLocust(Locust):
             task_set = RootTaskSet
 
-        l = MyLocust(config.locust_config)
+        l = MyLocust(config.locust_config())
         l.run()
         self.assertTrue(isinstance(parents["sub"], RootTaskSet))
         self.assertTrue(isinstance(parents["subsub"], SubTaskSet))
@@ -473,7 +473,7 @@ class TestWebLocustClass(WebserverTestCase):
         class MyLocust(WebLocust):
             task_set = MyTaskSet
 
-        my_locust = MyLocust(config.locust_config)
+        my_locust = MyLocust(config.locust_config())
         self.assertRaises(RescheduleTask, lambda: my_locust.client.http.get("/"))
         my_taskset = MyTaskSet(my_locust)
         self.assertRaises(RescheduleTask, lambda: my_taskset.client.http.get("/"))

--- a/locust/test/test_runners.py
+++ b/locust/test/test_runners.py
@@ -71,7 +71,7 @@ class TestMasterDefaultSlave(LocustTestCase):
         class MyTestLocust(Locust):
             pass
 
-        self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+        self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
         self.assertEqual(self.master.slave_count, 1)
 
 
@@ -93,7 +93,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "zeh_fake_client1"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
                 self.assertEqual(1, self.master.slave_count)
                 self.assertTrue(
@@ -119,7 +119,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "zeh_fake_client1"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
                 self.assertEqual(1, self.master.slave_count)
                 self.assertEqual(1, len(server.outbox_direct))
@@ -135,7 +135,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "zeh_fake_client1"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
                 self.assertEqual(1, self.master.slave_count)
                 server.outbox_all = []
@@ -156,7 +156,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "fake_client"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
 
                 self.master.stats.get("Task", "/", "GET").log(100, 23455)
@@ -185,7 +185,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "fake_client0"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 for i in range(1, 5):
                     server.mocked_send("all", Message("slave_ready", None, "fake_client%i" % i))
                     sleep(0)
@@ -212,7 +212,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "fake_client0"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
                 for i in range(1, 5):
                     server.mocked_send('all', Message("slave_ready", None, "fake_client%i" % i))
                     sleep(0)
@@ -240,7 +240,7 @@ class TestMasterRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.MasterServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.master.Process", mocked_process()):
                 server.mocked_send('all', Message("slave_ready", None, "fake_client0"))
-                self.master = MasterLocustRunner(MyTestLocust, config.locust_config)
+                self.master = MasterLocustRunner(MyTestLocust, config.locust_config())
 
                 sleep(0)
                 self.assertEqual(1, len(server.outbox_all))
@@ -270,7 +270,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.slave.Process", mocked_process()):
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 server.mocked_send('all', Message("worker_ready", None, "zeh_fake_client1"))
                 sleep(0)
                 self.slave.start_hatching(1, 1)
@@ -297,7 +297,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveClient", mocked_rpc_server()) as client:
             with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
                 self.assertEqual(2, len(client.outbox_all))
                 msg = {'host': 'custom_host.com', 'master_host': 'new_master_host.com'}
@@ -314,7 +314,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.slave.Process", mocked_process()):
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 server.mocked_send('all', Message("worker_ready", None, "fake_client"))
                 sleep(0)
                 self.slave.start_hatching(1, 1)
@@ -344,7 +344,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.slave.Process", mocked_process()):
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 server.mocked_send('all', Message("worker_ready", None, "fake_client0"))
                 sleep(0)
                 self.slave.start_hatching(1, 1)
@@ -374,7 +374,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
 
                 timeout = gevent.Timeout(3.0)
                 timeout.start()
@@ -399,7 +399,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.runners.slave.Process", mocked_process()):
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 server.mocked_send('all', Message("worker_ready", None, "fake_client0"))
                 self.slave.start_hatching(1, 1)
                 sleep(runners.slave.HEARTBEAT_INTERVAL)
@@ -422,7 +422,7 @@ class TestSlaveRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.rpc.rpc.SlaveClient", mocked_rpc_server()) as client:
                 with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                     server.mocked_send('all', Message("worker_ready", None, "fake_client0"))
                     self.slave.start_hatching(1, 1)
                     self.assertEqual(1, len(processes.started))
@@ -440,7 +440,7 @@ class TestSlaveRunner(LocustTestCase):
 
         with mock.patch("locust.rpc.rpc.SlaveClient", mocked_rpc_server()) as client:
             with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                 sleep(0)
                 self.assertEqual(2, len(client.outbox_all))
                 client.mocked_send('all', Message("ping", None, "master"))
@@ -456,7 +456,7 @@ class TestSlaveRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.rpc.rpc.SlaveClient", mocked_rpc_server()) as client:
                 with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                     for i in range(5):
                         server.mocked_send("all", Message("worker_ready", None, "fake_client%i" % i))
 
@@ -489,7 +489,7 @@ class TestSlaveRunner(LocustTestCase):
         with mock.patch("locust.rpc.rpc.SlaveServer", mocked_rpc_server()) as server:
             with mock.patch("locust.rpc.rpc.SlaveClient", mocked_rpc_server()) as client:
                 with mock.patch("locust.runners.slave.Process", mocked_process()) as processes:
-                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config)
+                    self.slave = SlaveLocustRunner(MyTestLocust, config.locust_config())
                     server.mocked_send('all', Message("worker_ready", None, "fake_client0"))
                     self.slave.start_hatching(1, 1)
 
@@ -524,7 +524,7 @@ class TestWorkerRunner(LocustTestCase):
             pass
 
         with mock.patch("locust.rpc.rpc.WorkerClient", mocked_rpc_server()) as client:
-            self.worker = WorkerLocustRunner(MyTestLocust, config.locust_config)
+            self.worker = WorkerLocustRunner(MyTestLocust, config.locust_config())
             sleep(0)
             self.assertEqual(2, len(client.outbox_all))
             client.mocked_send('all', Message("ping", None, "master"))
@@ -545,7 +545,7 @@ class TestWorkerRunner(LocustTestCase):
             max_wait = 100
 
         with mock.patch("locust.rpc.rpc.WorkerClient", mocked_rpc_server()) as client:
-            self.worker = WorkerLocustRunner([MyTestLocust], config.locust_config)
+            self.worker = WorkerLocustRunner([MyTestLocust], config.locust_config())
 
             data = {
                 "hatch_rate": 10,
@@ -566,7 +566,7 @@ class TestWorkerRunner(LocustTestCase):
 
 
         with mock.patch("locust.rpc.rpc.WorkerClient", mocked_rpc_server()) as client:
-            self.worker = WorkerLocustRunner([MyTestLocust], config.locust_config)
+            self.worker = WorkerLocustRunner([MyTestLocust], config.locust_config())
 
             self.worker.stats.get("Task", "/", "GET").log(100, 23455)
             self.worker.stats.get("Task", "/", "GET").log(800, 23455)
@@ -609,7 +609,7 @@ class TestLocustRunner(LocustTestCase):
             min_wait = 100
             max_wait = 100
 
-        self.runner = LocustRunner([MyTestLocust], config.locust_config)
+        self.runner = LocustRunner([MyTestLocust], config.locust_config())
 
         timeout = gevent.Timeout(2.0)
         timeout.start()
@@ -631,9 +631,9 @@ class TestLocustRunner(LocustTestCase):
                 def will_error(self):
                     raise HeyAnException(":(")
 
-        self.runner = LocustRunner([MyLocust], config.locust_config)
+        self.runner = LocustRunner([MyLocust], config.locust_config())
 
-        l = MyLocust(config.locust_config)
+        l = MyLocust(config.locust_config())
         l._catch_exceptions = False
 
         self.assertRaises(HeyAnException, l.run)
@@ -671,8 +671,8 @@ class TestLocustRunner(LocustTestCase):
             max_wait = 10
             task_set = MyTaskSet
 
-        self.runner = LocustRunner([MyLocust], config.locust_config)
-        l = MyLocust(config.locust_config)
+        self.runner = LocustRunner([MyLocust], config.locust_config())
+        l = MyLocust(config.locust_config())
 
         # supress stderr
         with mock.patch("sys.stderr") as mocked:

--- a/locust/test/test_socketio.py
+++ b/locust/test/test_socketio.py
@@ -3,6 +3,7 @@ import gevent
 from gevent import pywsgi
 from locust.clients import SocketIOClient
 from locust.stats import global_stats
+from locust import config
 from .testcases import LocustTestCase
 
 class SimpleSocketIOServer(object):
@@ -54,7 +55,7 @@ class SimpleSocketIOServer(object):
 
     def run(self):
         app = socketio.Middleware(self.sio)
-        self.server = pywsgi.WSGIServer(('127.0.0.1', 8080), app)
+        self.server = pywsgi.WSGIServer(('127.0.0.1', 8081), app)
         self.server.init_socket()
         self.server.start()
 
@@ -84,46 +85,46 @@ class TestSocketIO(LocustTestCase):
         self.server.stop()
 
     def test_connect_disconnect(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.assertEqual(len(self.server.clients), 1)
         gevent.sleep(0.5)
         self.client.close()
         self.assertEqual(len(self.server.clients), 0)
 
     def test_send_async(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('async_message', {'key': 'value'})
         self.assertIn({'async_message': {'key': 'value'}}, self.server.messages)
 
     def test_send_sync(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         payload = {'key': 'value'}
         result = self.client.send_sync('sync_message', payload, response='reply-sync-message')
         self.assertIn({'sync_message': {'key': 'value'}}, self.server.messages)
         self.assertEqual(result.payload, {'key1': 'value1'})
 
     def test_reconnect(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('self_disconnect', {})
         self.assertEqual(len(self.server.clients), 0)
         self.client._socket.wait(1)
         self.assertEqual(len(self.server.clients), 1)
 
     def test_wait_for_message(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('wait_for_message', ['long_wait'])
         result = self.client.wait_for_message('long_wait')
         self.assertEqual(result.payload, {'key1': 'value1'})
 
     def test_wait_for_message_with_condition(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('wait_for_message', ['stub'])
         condition = lambda msg: 'key1' in msg.payload.keys()
         result = self.client.wait_for_message('stub', condition=condition)
         self.assertEqual(result.payload, {'key1': 'value1'})
 
     def test_wait_for_message_with_amount(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('wait_for_message_amount', 5)
         messages = self.client.wait_for_message_amount(5)
         self.assertEqual(len(messages), 5)
@@ -134,7 +135,7 @@ class TestSocketIO(LocustTestCase):
         self.server = SimpleSocketIOServer('/test')
         self.server.run()
         gevent.sleep(0.5)
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '/test')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '/test')
         self.assertEqual(len(self.server.clients), 1)
         payload = {'key': 'value'}
         result = self.client.send_sync('sync_message', payload, response='reply-sync-message')
@@ -146,7 +147,7 @@ class TestSocketIO(LocustTestCase):
         self.assertEqual(len(self.server.clients), 2)
 
     def test_stats_tracking(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('async_message', {'key': 'value'})
         self.assertEqual(global_stats.num_requests, 1)
         self.assertIn(
@@ -159,7 +160,7 @@ class TestSocketIO(LocustTestCase):
         )
 
     def test_custom_action_name(self):
-        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8080', 'socket.io', '')
+        self.client = SocketIOClient(Locust, 'http://127.0.0.1:8081', 'socket.io', '')
         self.client.send_async('async_message', {'key': 'value'}, description='test_namespace')
         self.assertEqual(global_stats.num_requests, 1)
         self.assertIn(

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -23,7 +23,7 @@ class TestWebUI(LocustTestCase):
         stats.global_stats.clear_all()
         # parser = parse_options()[0]
         # options = parser.parse_args([])[0]
-        runners.main = MasterLocustRunner([], config.locust_config)
+        runners.main = MasterLocustRunner([], config.locust_config())
 
         web.request_stats.clear_cache()
 

--- a/locust/test/test_web.py
+++ b/locust/test/test_web.py
@@ -9,7 +9,7 @@ import requests
 from gevent import wsgi
 
 from locust import runners, stats, web
-from locust.config import parse_options
+from locust import config
 from locust.runners import MasterLocustRunner
 from six.moves import StringIO
 
@@ -19,75 +19,78 @@ from .testcases import LocustTestCase
 class TestWebUI(LocustTestCase):
     def setUp(self):
         super(TestWebUI, self).setUp()
-        
+
         stats.global_stats.clear_all()
-        parser = parse_options()[0]
-        options = parser.parse_args([])[0]
-        runners.main = MasterLocustRunner([], options)
-        
+        # parser = parse_options()[0]
+        # options = parser.parse_args([])[0]
+        runners.main = MasterLocustRunner([], config.locust_config)
+
         web.request_stats.clear_cache()
-        
+
         self._web_ui_server = wsgi.WSGIServer(('127.0.0.1', 0), web.app, log=None)
         gevent.spawn(lambda: self._web_ui_server.serve_forever())
         gevent.sleep(0.5)
         self.web_port = self._web_ui_server.server_port
-    
+
     def tearDown(self):
         super(TestWebUI, self).tearDown()
         self._web_ui_server.stop()
         runners.main.quit()
         gevent.sleep(0.5)
-    
+
     def test_index(self):
         self.assertEqual(200, requests.get("http://127.0.0.1:%i/" % self.web_port).status_code)
-    
+
     def test_stats_no_data(self):
-        self.assertEqual(200, requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code)
-    
+        self.assertEqual(
+            200,
+            requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).status_code
+        )
+
     def test_stats(self):
         stats.global_stats.get(None, "/test", "GET").log(120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+
         data = json.loads(response.text)
         self.assertEqual(2, len(data["stats"])) # one entry plus Total
         self.assertEqual("/test", data["stats"][0]["name"])
         self.assertEqual("GET", data["stats"][0]["method"])
         self.assertEqual(120, data["stats"][0]["avg_response_time"])
-        
+
     def test_stats_cache(self):
         stats.global_stats.get(None, "/test", "GET").log(120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
         data = json.loads(response.text)
         self.assertEqual(2, len(data["stats"])) # one entry plus Total
-        
+
         # add another entry
         stats.global_stats.get(None, "/test2", "GET").log(120, 5612)
         data = json.loads(requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).text)
         self.assertEqual(2, len(data["stats"])) # old value should be cached now
-        
+
         web.request_stats.clear_cache()
-        
+
         data = json.loads(requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port).text)
         self.assertEqual(3, len(data["stats"])) # this should no longer be cached
-    
+
     def test_request_stats_csv(self):
         stats.global_stats.get(None, "/test", "GET").log(120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/requests/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_distribution_stats_csv(self):
         stats.global_stats.get(None, "/test", "GET").log(120, 5612)
         response = requests.get("http://127.0.0.1:%i/stats/distribution/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_request_stats_with_errors(self):
         stats.global_stats.get(None, "/", "GET").log_error(Exception("Error1337"))
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
         self.assertIn("Error1337", str(response.content))
-    
+
     def test_exceptions(self):
         try:
             raise Exception(u"A cool test exception")
@@ -95,14 +98,14 @@ class TestWebUI(LocustTestCase):
             tb = sys.exc_info()[2]
             runners.main.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             runners.main.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
-        
+
         response = requests.get("http://127.0.0.1:%i/exceptions" % self.web_port)
         self.assertEqual(200, response.status_code)
         self.assertIn("A cool test exception", str(response.content))
-        
+
         response = requests.get("http://127.0.0.1:%i/stats/requests" % self.web_port)
         self.assertEqual(200, response.status_code)
-    
+
     def test_exceptions_csv(self):
         try:
             raise Exception("Test exception")
@@ -110,15 +113,15 @@ class TestWebUI(LocustTestCase):
             tb = sys.exc_info()[2]
             runners.main.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
             runners.main.log_exception("local", str(e), "".join(traceback.format_tb(tb)))
-        
+
         response = requests.get("http://127.0.0.1:%i/exceptions/csv" % self.web_port)
         self.assertEqual(200, response.status_code)
-        
+
         reader = csv.reader(StringIO(response.text))
         rows = []
         for row in reader:
             rows.append(row)
-        
+
         self.assertEqual(2, len(rows))
         self.assertEqual("Test exception", rows[1][1])
         self.assertEqual(2, int(rows[1][0]), "Exception count should be 2")


### PR DESCRIPTION
**RATIONALE**
Current PR is based on https://github.com/datarobot/locust/pull/2/files
As part of investigation QA-2763 I found out that SocketIO client is not able to handle properly ERRNO 35 tcp socket for websocket communication error which risen because of attempt for blocking receive in non-blocking connection. Currently SocketIO client react as for all other communication breaks and tries to do unnecessary reconnect.

**CHANGES**
* Added proper handling of tcp ERRNO 35 in websocket part of socketio communication
* All other tcp error would rise an exception so it would be easily tracked in report
* If any other tcp ERROR occurs exception would be raised, which cause user scenario interrupt. On further access to client reconnect will be executed.

**AFTER MERGE**
* New version of locust should be deployed to artifactory
* Cicada locust version reference should be updated
* https://github.com/datarobot/locust/pull/2/files should be closed

**JIRA**
https://datarobot.atlassian.net/browse/QA-2763