### PR TITLE
[QA-2763] Added stablization fixes

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,13 @@
 Changelog
 ##########
 
+0.8dr4
+=====
+* Based on 0.8dr3
+* Various stabilization improvements and fixes:
+** Ignoring unkonwn nodes
+** Handling socket-io EAGAIN tcp statuses
+
 0.8dr3
 =====
 * Based on 0.8dr2

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .config import configure, locust_config, register_config
 
-__version__ = "0.8dr3"
+__version__ = "0.8dr4"

--- a/locust/clients/http.py
+++ b/locust/clients/http.py
@@ -37,7 +37,7 @@ def fire_failure(meta, task, exception):
         response_time=meta["response_time"],
         exception=exception,
         task=task
-    )   
+    )
 
 class LocustResponse(Response):
 

--- a/locust/clients/http.py
+++ b/locust/clients/http.py
@@ -236,7 +236,7 @@ class HttpSession(LoggedSession):
                 response.raise_for_status()
             except HTTPError as exception:
                 error = exception.message.split('for url:')[0]
-                message = "{}for: {} {} ".format(error, method, request_meta["name"])
+                message = "{} for: {} {} ".format(error, method, request_meta["name"])
                 exception = exception.__class__(
                     message,
                     request=exception.request,

--- a/locust/clients/socketio.py
+++ b/locust/clients/socketio.py
@@ -199,6 +199,13 @@ class SocketIOClient(object):
                 pass
 
             def on_disconnect(self, reason):
+                LocustEventHandler.request_failure.fire(
+                    request_type='SocketIO',
+                    name='Websocket connection',
+                    response_time=-1,
+                    exception=SocketIODisconnectedError('SocketIO websocket exection: ' + reason),
+                    task=client_wrapper.binded_locust.current_task
+                )
                 raise SocketIODisconnectedError('SocketIO websocket exection: ' + reason)
 
             def on_event(self, event, *args):

--- a/locust/clients/socketio.py
+++ b/locust/clients/socketio.py
@@ -152,7 +152,7 @@ class ExtendedSocketIO(SocketIO):
                     self._close()
                     raise
             except SocketIOConnectionError as e:
-                if e.errno == 35:
+                if e.errno in [11, 35]:
                     # EAGAIN error, no data for tcp connection for now
                     continue
 

--- a/locust/config.py
+++ b/locust/config.py
@@ -65,7 +65,7 @@ class LocustConfig(object):
         'http_logging': 'ERROR',
         'socketio_logging': 'ERROR',
         'zmq_logging': 'ERROR',
-        'locust_logging': 'ERROR',
+        'locust_logging': 'WARN',
         'logfile': None
     }
 

--- a/locust/core.py
+++ b/locust/core.py
@@ -431,13 +431,15 @@ class TaskSet(object):
     def _sleep(self, seconds):
         gevent.sleep(seconds)
 
-    def fire_task_success(self, start_time, task_name=self.locust.current_task):
+    def fire_task_success(self, start_time, task_name=None):
+        task_name = self.locust.current_task if task_name is None else task_name
         events.task_success.fire(
             task_name=task_name,
             task_time=int((time() - start_time) * 1000)
         )
 
-    def fire_task_failure(self, start_time, reason, action, task_name=self.locust.current_task):
+    def fire_task_failure(self, start_time, reason, action, task_name=None):
+        task_name = self.locust.current_task if task_name is None else task_name
         events.task_failure.fire(
             task_name=task_name,
             task_time=int((time() - start_time) * 1000),

--- a/locust/core.py
+++ b/locust/core.py
@@ -356,6 +356,9 @@ class TaskSet(object):
                 try:
                     if hasattr(self, 'on_task_end'):
                         self.on_task_end()
+                    self.client.clear_context()
+                except InterruptTaskSet as e:
+                    raise e
                 except Exception as e:
                     self.fire_task_failure(
                         task_start_time,
@@ -363,7 +366,6 @@ class TaskSet(object):
                         'After Task Hook',
                         task_name='After Task Hook'
                 )
-                self.client.clear_context()
             except InterruptTaskSet as e:
                 if e.reschedule:
                     six.reraise(RescheduleTaskImmediately, RescheduleTaskImmediately(e.reschedule), sys.exc_info()[2])

--- a/locust/runners/master.py
+++ b/locust/runners/master.py
@@ -69,7 +69,10 @@ class MasterLocustRunner(DistributedLocustRunner):
             self.master.log_exception(msg.node_id, msg.data["msg"], msg.data["traceback"])
 
         def on_pong(self, msg):
-            self.master.slaves[msg.node_id].ping_answ = True
+            if msg.node_id in self.master.slaves.keys():
+                self.master.slaves[msg.node_id].ping_answ = True
+            else:
+                logger.warn('Unknown Slave pong: {}.'.format(msg.node_id))
 
 
     def __init__(self, locust_classes, options):

--- a/locust/runners/slave.py
+++ b/locust/runners/slave.py
@@ -81,7 +81,7 @@ class SlaveLocustRunner(DistributedLocustRunner):
                         msg.node_id, Message("quit", None, inst.slave.slave_id)
                     )
             return wraper
-        
+
         def on_worker_ready(self, msg):
             id = msg.node_id.encode('ascii')
             self.slave.workers[id] = Node(id)

--- a/locust/runners/slave.py
+++ b/locust/runners/slave.py
@@ -106,7 +106,10 @@ class SlaveLocustRunner(DistributedLocustRunner):
             events.node_report.fire(node_id=msg.node_id, data=msg.data)
 
         def on_pong(self, msg):
-            self.slave.workers[msg.node_id].ping_answ = True
+            if msg.node_id in self.slave.workers.keys():
+                self.slave.workers[msg.node_id].ping_answ = True
+            else:
+                logger.warn('Unknown Worker pong: {}.'.format(msg.node_id))
 
 
     @classmethod
@@ -143,7 +146,11 @@ class SlaveLocustRunner(DistributedLocustRunner):
 
         # listener that gathers info on how many locust users the slaves has spawned
         def on_worker_report(node_id, data):
-            self.workers[node_id].user_count = data["user_count"]
+            if node_id in self.workers:
+                self.workers[node_id].user_count = data["user_count"]
+            else:
+                logger.warn('Unknown Worker report: {}.'.format(node_id))
+
         events.node_report += on_worker_report
 
         # register listener that adds the current number of

--- a/locust/runners/worker.py
+++ b/locust/runners/worker.py
@@ -280,7 +280,7 @@ class WorkerLocustRunner(LocustRunner):
         events.locust_error += on_locust_error
 
         self.greenlet.spawn(self.slave_listener).link_exception(callback=noop)
-        gevent.sleep(0.5)
+        gevent.sleep(2)
         self.client.send_all(Message("worker_ready", None, self.worker_id))
         self.greenlet.spawn(self.stats_reporter).link_exception(callback=noop)
 

--- a/locust/test/test_http_client.py
+++ b/locust/test/test_http_client.py
@@ -40,6 +40,8 @@ class TestHttpSession(WebserverTestCase):
         """
         Test a request to an endpoint that returns a streaming response
         """
+        from locust.clients.http import logger
+        logger.setLevel('WARN')
         s = HttpSession(Locust, "http://127.0.0.1:%i" % self.port)
         r = s.get("/streaming/30")
         

--- a/locust/test/test_stats.py
+++ b/locust/test/test_stats.py
@@ -315,6 +315,7 @@ class TestLocustTaskStatistics(unittest.TestCase):
             @task
             def t1(self):
                 pass
+        
         loc = MyTasks(self.locust)
         self.assertRaises(RescheduleTask, lambda: loc.run())
         self.assertEqual(len(global_stats.tasks), 1)


### PR DESCRIPTION
### Summary of Changes
Introduced stabilization fixes for socket-io client and internodes communication 

### Rationale
To reduce test flakiness caused by locust app itself its needed to handle all possible communication crushes

### Relevant JIRA links
https://datarobot.atlassian.net/browse/QA-2821

### How was this change tested?
Tested locally by various launches and via unittests

### TODO after merging

- [] Build package for artifactory
- [] Updated cicada locust version
