### PR TITLE
[QA-2966] Moved from fork to subprocess

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -2,6 +2,12 @@
 Changelog
 ##########
 
+0.8dr5
+=====
+* Based on 0.8dr4
+* Moved from process fork to subprocess spawn
+* Changed ping-pong logic for missed ping calculation
+
 0.8dr4
 =====
 * Based on 0.8dr3

--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .config import configure, locust_config, register_config
 
-__version__ = "0.8dr4"
+__version__ = "0.8dr5"

--- a/locust/config.py
+++ b/locust/config.py
@@ -116,6 +116,12 @@ class LocustConfig(object):
         else:
             self._config[attr] = value
 
+    def __getstate__(self):
+        return self.__dict__
+    
+    def __setstate__(self, d):
+        self.__dict__.update(d)
+
 # global locust config singleton
 _locust_config = LocustConfig()
 

--- a/locust/core.py
+++ b/locust/core.py
@@ -16,7 +16,7 @@ from .clients import HttpSession, SocketIOClient, ZMQClient
 from .exception import (InterruptTaskSet, LocustError, RescheduleTask,
                         RescheduleTaskImmediately, StopLocust)
 
-monkey.patch_all(thread=False)
+monkey.patch_all()
 logger = logging.getLogger(__name__)
 
 

--- a/locust/runners/distributed.py
+++ b/locust/runners/distributed.py
@@ -14,6 +14,7 @@ class Node(object):
         self.state = state
         self.user_count = 0
         self.ping_answ = True
+        self.ping_missed = 0
         self.worker_count = 0
         self.task = None
 

--- a/locust/runners/subrunner.py
+++ b/locust/runners/subrunner.py
@@ -1,0 +1,38 @@
+"""Module for creation subrunner through subprocess to avoid main process fork"""
+import pickle
+from optparse import OptionParser
+
+from gevent import monkey
+
+from locust.config import LocustConfig, load_locustfile
+from locust.runners.slave import SlaveLocustRunner
+from locust.runners.worker import WorkerLocustRunner
+
+def main():
+    monkey.patch_all()
+
+    parser = OptionParser()
+
+    parser.add_option(
+        '--process',
+        dest="process"
+    )
+
+    parser.add_option(
+        '--options',
+        dest="options"
+    )
+
+    opts, args = parser.parse_args()
+    options = pickle.loads(opts.options)
+    locusts = [l for f in args for l in load_locustfile(f)[1].values()]
+
+    if opts.process == 'slave':
+        runner = SlaveLocustRunner(locusts, options)
+        runner.greenlet.join()
+    elif opts.process == 'worker':
+        runner = WorkerLocustRunner(locusts, options)
+        runner.greenlet.join()
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "requests>=2.9.1",
         "msgpack-python>=0.4.2",
         "six>=1.10.0",
-        "pyzmq>=15.4.0,<16",
+        "pyzmq>=15.4.0,<17",
         "socketIO-client>=0.7.2,<0.8"
     ],
     tests_require=['unittest2', 'mock', 'python-socketio'],


### PR DESCRIPTION
To reduce artifacts happened during process forking with running greenlets and zmq connections moved from process fork to subprocess spawn.