### PR TITLE
[CICADA-29] Adding --run-time option when running headless

### DIFF
--- a/locust/__init__.py
+++ b/locust/__init__.py
@@ -2,4 +2,4 @@ from .core import WebLocust, Locust, TaskSet, task, mod_context
 from .exception import InterruptTaskSet, ResponseError, RescheduleTaskImmediately
 from .config import configure, locust_config, register_config
 
-__version__ = "0.8dr5"
+__version__ = "0.8dr6"

--- a/locust/config.py
+++ b/locust/config.py
@@ -290,6 +290,16 @@ def parse_options():
         help="The rate per second in which clients are spawned. Only used together with --no-web"
     )
 
+    # Time limit of the test run
+    parser.add_option(
+        '-t', '--run-time',
+        action='store',
+        type='str',
+        dest='run_time',
+        default=None,
+        help="Stop after the specified amount of time, e.g. (300s, 20m, 3h, 1h30m, etc.). Only used together with --no-web"
+    )
+
     # Number of requests
     parser.add_option(
         '-n', '--num-request',

--- a/locust/runners/worker.py
+++ b/locust/runners/worker.py
@@ -28,6 +28,7 @@ class LocustRunner(object):
         self.options = options
         self.locust_classes = locust_classes
         self.locusts = Group()
+        self.greenlet = self.locusts
         self.state = STATE.INIT
         self.hatching_greenlet = None
         self.exceptions = {}

--- a/locust/test/test_util.py
+++ b/locust/test/test_util.py
@@ -1,0 +1,16 @@
+import unittest
+from locust.util.time import parse_timespan
+
+
+class TestParseTimespan(unittest.TestCase):
+    def test_parse_timespan_invalid_values(self):
+        self.assertRaises(ValueError, parse_timespan, None)
+        self.assertRaises(ValueError, parse_timespan, "")
+        self.assertRaises(ValueError, parse_timespan, "q")
+
+    def test_parse_timespan(self):
+        self.assertEqual(7, parse_timespan("7"))
+        self.assertEqual(7, parse_timespan("7s"))
+        self.assertEqual(60, parse_timespan("1m"))
+        self.assertEqual(7200, parse_timespan("2h"))
+        self.assertEqual(3787, parse_timespan("1h3m7s"))

--- a/locust/util/time.py
+++ b/locust/util/time.py
@@ -1,0 +1,24 @@
+import re
+from datetime import timedelta
+
+def parse_timespan(time_str):
+    """
+    Parse a string representing a time span and return the number of seconds.
+    Valid formats are: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.
+    """
+    if not time_str:
+        raise ValueError("Invalid time span format")
+
+    if re.match(r'^\d+$', time_str):
+        # if an int is specified we assume they want seconds
+        return int(time_str)
+
+    timespan_regex = re.compile(r'((?P<hours>\d+?)h)?((?P<minutes>\d+?)m)?((?P<seconds>\d+?)s)?')
+    parts = timespan_regex.match(time_str)
+    if not parts:
+        raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
+    parts = parts.groupdict()
+    time_params = {name:int(value) for name, value in parts.items() if value}
+    if not time_params:
+        raise ValueError("Invalid time span format. Valid formats: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.")
+    return int(timedelta(**time_params).total_seconds())


### PR DESCRIPTION
- Adds **--run-time** option when running in headless mode. Valid formats are: 20, 20s, 3m, 2h, 1h20m, 3h30m10s, etc.

Added the option from locust's 0.9.0v. PR: https://github.com/locustio/locust/pull/656

The original PR removes --num-requests option, yet this is not what we are doing here -- in case somebody still finds it useful, it doesn't hurt being there.
 
Paired with PR in Cicada that adds the option there: https://github.com/datarobot/cicada/pull/84

